### PR TITLE
Use Go 1.21 finally

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ package main
 
 import (
 	"github.com/m-mizutani/clog"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 func main() {

--- a/color.go
+++ b/color.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 type ColorMap struct {

--- a/config.go
+++ b/config.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"text/template"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 // config is the configuration for the handler. The struct is immutable after creation.

--- a/examples/attr_printer/main.go
+++ b/examples/attr_printer/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/m-mizutani/clog"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 type User struct {

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/m-mizutani/clog"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/m-mizutani/clog
 
-go 1.20
+go 1.21
 
 require (
 	github.com/fatih/color v1.15.0

--- a/handler.go
+++ b/handler.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/m-mizutani/goerr"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 // Handler is a slog handler that writes logs to an io.Writer.

--- a/handler_test.go
+++ b/handler_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/m-mizutani/clog"
 	"github.com/m-mizutani/gt"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 func TestWithGroup(t *testing.T) {

--- a/log.go
+++ b/log.go
@@ -4,7 +4,7 @@ import (
 	"runtime"
 	"time"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 type Log struct {

--- a/printer.go
+++ b/printer.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/k0kubun/pp/v3"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 type AttrPrinter interface {


### PR DESCRIPTION
- Update go to 1.21
- Use `log/slog` instead of `golang.org/x/exp/slog`