### PR TITLE
Add AttrHook

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -1,0 +1,43 @@
+package clog
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/m-mizutani/goerr"
+)
+
+// HandleAttr is a struct that describes how to handle an attribute.
+// NOTE: This feature is experimental and may be changed in the future.
+// NOTE: This feature is available only in the LinearPrinter for now.
+type HandleAttr struct {
+	// NewAttr is a new attribute that replaces the original attribute. When this field is not nil, the original attribute is not printed.
+	NewAttr *slog.Attr
+
+	// Defer is a function that is called after the all attributes are printed.
+	Defer func(w io.Writer)
+}
+
+// AttrHook is a function that hooks attribute printing. When the function returns nil, the attribute is printed as usual. When the function returns a non-nil value, the attribute is handled according to the content of HandleAttr.
+type AttrHook func(groups []string, attr slog.Attr) *HandleAttr
+
+// GoerrHook is a hook function that hides the goerr.Error attribute and prints the error message.
+func GoerrHook(_ []string, attr slog.Attr) *HandleAttr {
+	if goErr, ok := attr.Value.Any().(*goerr.Error); ok {
+		var attrs []any
+		for k, v := range goErr.Values() {
+			attrs = append(attrs, slog.Any(k, v))
+		}
+		newAttr := slog.Group(attr.Key, attrs...)
+
+		return &HandleAttr{
+			NewAttr: &newAttr,
+			Defer: func(w io.Writer) {
+				fmt.Fprintf(w, "Error: %+v", goErr)
+			},
+		}
+	}
+
+	return nil
+}

--- a/attr_test.go
+++ b/attr_test.go
@@ -1,0 +1,94 @@
+package clog_test
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/m-mizutani/clog"
+	"github.com/m-mizutani/gt"
+)
+
+func toPtr[T any](v T) *T {
+	return &v
+}
+
+func TestHandleAttr(t *testing.T) {
+	type testCase struct {
+		hook clog.AttrHook
+		test func(t *testing.T, s string, attrs []slog.Attr)
+	}
+
+	runTest := func(tc testCase) func(t *testing.T) {
+		return func(t *testing.T) {
+			var hooked []slog.Attr
+			var buf bytes.Buffer
+			logger := slog.New(clog.New(
+				clog.WithWriter(&buf),
+				clog.WithAttrHook(func(groups []string, attr slog.Attr) *clog.HandleAttr {
+					hooked = append(hooked, attr)
+					return tc.hook(groups, attr)
+				}),
+			))
+			logger.Info("hello, world!",
+				slog.String("color", "blue"),
+				slog.Any("number", 5),
+				slog.Group("magic", slog.String("words", "timeless")),
+			)
+
+			tc.test(t, buf.String(), hooked)
+		}
+	}
+
+	t.Run("no action", runTest(testCase{
+		hook: func(_ []string, _ slog.Attr) *clog.HandleAttr {
+			return nil
+		},
+		test: func(t *testing.T, s string, attrs []slog.Attr) {
+			gt.S(t, s).
+				Contains("hello, world!").
+				Contains(`color="blue"`).
+				Contains(`number=5`)
+		},
+	}))
+
+	t.Run("replace attribute", runTest(testCase{
+		hook: func(_ []string, attr slog.Attr) *clog.HandleAttr {
+			if attr.Key == "color" {
+				return &clog.HandleAttr{
+					NewAttr: toPtr(slog.String("color", "red")),
+				}
+			}
+			return nil
+		},
+		test: func(t *testing.T, s string, attrs []slog.Attr) {
+			gt.S(t, s).
+				Contains("hello, world!").
+				Contains(`color="red"`).
+				NotContains(`color="blue"`).
+				Contains(`number=5`)
+		},
+	}))
+
+	t.Run("defer action", runTest(testCase{
+		hook: func(_ []string, attr slog.Attr) *clog.HandleAttr {
+			if attr.Key == "color" {
+				return &clog.HandleAttr{
+					NewAttr: toPtr(slog.String("color", "red")),
+					Defer: func(w io.Writer) {
+						gt.R1(w.Write([]byte("deferred!"))).NoError(t)
+					},
+				}
+			}
+			return nil
+		},
+		test: func(t *testing.T, s string, attrs []slog.Attr) {
+			gt.S(t, s).
+				Contains("hello, world!").
+				Contains(`color="red"`).
+				Contains("deferred!").
+				Contains(`number=5`)
+		},
+	}))
+}

--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ type config struct {
 	newPrinter  func(io.Writer, *config) AttrPrinter
 	colors      *ColorMap
 	tmpl        *template.Template
+	attrHooks   []AttrHook
 }
 
 func newConfig() *config {
@@ -131,5 +132,12 @@ func WithTemplate(tmpl *template.Template) Option {
 		}
 
 		cfg.tmpl = tmpl
+	}
+}
+
+// WithAttrHook adds an attribute hook to the handler. This option can be used with only LinearPrinter.
+func WithAttrHook(hook AttrHook) Option {
+	return func(cfg *config) {
+		cfg.attrHooks = append(cfg.attrHooks, hook)
 	}
 }

--- a/examples/attr_handler/main.go
+++ b/examples/attr_handler/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/m-mizutani/clog"
+	"github.com/m-mizutani/goerr"
+)
+
+func someAction(args string) error {
+	return goerr.New("something wrong").With("args", args)
+}
+
+func main() {
+	options := []clog.Option{
+		clog.WithColor(false),
+	}
+
+	if _, ok := os.LookupEnv("HANDLE_ERROR"); ok {
+		options = append(options, clog.WithAttrHook(clog.GoerrHook))
+	}
+
+	logger := slog.New(clog.New(options...))
+
+	err := someAction("foo")
+	logger.Error("oops", "error", err)
+}

--- a/handler.go
+++ b/handler.go
@@ -7,8 +7,9 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/m-mizutani/goerr"
 	"log/slog"
+
+	"github.com/m-mizutani/goerr"
 )
 
 // Handler is a slog handler that writes logs to an io.Writer.
@@ -163,6 +164,8 @@ func printAttrs(p AttrPrinter, attrs []slog.Attr) {
 			p.Print(attr)
 		}
 	}
+
+	p.Defer()
 }
 
 // WithAttrs implements slog.Handler.


### PR DESCRIPTION
The PR adds the feature to handle attribute one by one. `WithAttrHook` with `AttrHook` function can set hook before printing.

`AttrHook` function returns `AttrHandle`. It can control:

- `NewAttr`: Replace `slog.Attr` with the one. If it's null, printing is skipped
- `Defer`: If the field is set, call the function after printing all attribute

# `GoerrHook`

The PR also adds `GoerrHook` to handle [m-mizutani/goerr](https://github.com/m-mizutani/goerr).

## Before

```go
	logger := slog.New(clog.New(
		clog.WithColor(false),
	))

	if err := someAction("foo"); err != nil {
		logger.Error("oops", "error", err)
	}
```

This will output:

```bash
10:33:40.510 ERROR oops error=[message=something wrong values=[args=foo] stacktrace=[/Users/mizutani/.ghq/github.com/m-mizutani/clog/examples/attr_handler/main.go:13 main.someAction /Users/mizutani/.ghq/github.com/m-mizutani/clog/examples/attr_handler/main.go:32 main.withoutGoerrHook /Users/mizutani/.ghq/github.com/m-mizutani/clog/examples/attr_handler/main.go:23 main.main /usr/local/go/src/runtime/proc.go:271 runtime.main /usr/local/go/src/runtime/asm_arm64.s:1222 runtime.goexit]]
```

## After

```go
	logger := slog.New(clog.New(
		clog.WithColor(false),
		clog.WithAttrHook(clog.GoerrHook),
	))

	if err := someAction("foo"); err != nil {
		logger.Error("oops", "error", err)
	}
```

This will output:

```bash
10:34:22.810 ERROR oops error=[args=foo] Error: something wrong
main.someAction
        /Users/mizutani/.ghq/github.com/m-mizutani/clog/examples/attr_handler/main.go:13
main.withGoerrHook
        /Users/mizutani/.ghq/github.com/m-mizutani/clog/examples/attr_handler/main.go:43
main.main
        /Users/mizutani/.ghq/github.com/m-mizutani/clog/examples/attr_handler/main.go:21
runtime.main
        /usr/local/go/src/runtime/proc.go:271
runtime.goexit
        /usr/local/go/src/runtime/asm_arm64.s:1222
```


