### PR TITLE
feat(logging): add custom level formatter functionality 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+/.cckiro
+

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ func main() {
 - `WithReplaceAttr`: Replace attribute value. It's same with `slog.ReplaceAttr` in `slog.HandlerOptions`.
 - `WithTemplate`: Template string. See [Template](#template) section for more detail.
 - `WithAttrPrinter`: Attribute printer. Default is `clog.LinearPrinter`. See [AttrPrinter](#attrprinter) section for more detail.
+- `WithLevelFormatter`: Custom function to format log level strings. Default uses `level.String()`.
 
 ### ColorMap
 

--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ type config struct {
 	colors         *ColorMap
 	tmpl           *template.Template
 	attrHooks      []AttrHook
+	levelFormatter func(slog.Level) string
 }
 
 func newConfig() *config {
@@ -32,8 +33,9 @@ func newConfig() *config {
 		enableColor:    enableColorDefault,
 		newAttrPrinter: LinearPrinter,
 
-		colors: defaultColorMap,
-		tmpl:   defaultTmpl,
+		colors:         defaultColorMap,
+		tmpl:           defaultTmpl,
+		levelFormatter: DefaultLevelFormatter,
 	}
 }
 
@@ -139,5 +141,22 @@ func WithTemplate(tmpl *template.Template) Option {
 func WithAttrHook(hook AttrHook) Option {
 	return func(cfg *config) {
 		cfg.attrHooks = append(cfg.attrHooks, hook)
+	}
+}
+
+// DefaultLevelFormatter is the default function for formatting log level strings.
+// This is exported so users can build custom formatters based on the default behavior.
+func DefaultLevelFormatter(level slog.Level) string {
+	return level.String()
+}
+
+// WithLevelFormatter sets the function for formatting log level strings.
+// The function receives a slog.Level and returns a formatted string.
+// If nil is passed, the default formatter is used.
+func WithLevelFormatter(f func(slog.Level) string) Option {
+	return func(cfg *config) {
+		if f != nil {
+			cfg.levelFormatter = f
+		}
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,108 @@
+package clog_test
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/m-mizutani/clog"
+	"github.com/m-mizutani/gt"
+)
+
+func TestWithLevelFormatter(t *testing.T) {
+	// Test custom level formatter
+	customFormatter := func(level slog.Level) string {
+		switch level {
+		case slog.LevelDebug:
+			return "DEBUG"
+		case slog.LevelInfo:
+			return "INFO "
+		case slog.LevelWarn:
+			return "WARN "
+		case slog.LevelError:
+			return "ERROR"
+		default:
+			return fmt.Sprintf("%-5s", level.String())
+		}
+	}
+
+	buf := &bytes.Buffer{}
+	handler := clog.New(
+		clog.WithWriter(buf),
+		clog.WithLevelFormatter(customFormatter),
+		clog.WithColor(false),
+	)
+	logger := slog.New(handler)
+
+	testCases := []struct {
+		level    slog.Level
+		logFunc  func(string, ...any)
+		expected string
+	}{
+		{slog.LevelInfo, logger.Info, "INFO "},
+		{slog.LevelWarn, logger.Warn, "WARN "},
+		{slog.LevelError, logger.Error, "ERROR"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.level.String(), func(t *testing.T) {
+			buf.Reset()
+			tc.logFunc("test message")
+			output := buf.String()
+			gt.S(t, output).Contains(tc.expected)
+			gt.S(t, output).Contains("test message")
+		})
+	}
+}
+
+func TestWithLevelFormatterNil(t *testing.T) {
+	// Test that nil formatter doesn't break the handler
+	buf := &bytes.Buffer{}
+	handler := clog.New(
+		clog.WithWriter(buf),
+		clog.WithLevelFormatter(nil), // Should use default
+		clog.WithColor(false),
+	)
+	logger := slog.New(handler)
+
+	logger.Info("test message")
+	output := buf.String()
+	gt.S(t, output).Contains("INFO")
+	gt.S(t, output).Contains("test message")
+}
+
+func TestDefaultLevelFormatter(t *testing.T) {
+	// Test that DefaultLevelFormatter works as expected
+	testCases := []struct {
+		level    slog.Level
+		expected string
+	}{
+		{slog.LevelDebug, "DEBUG"},
+		{slog.LevelInfo, "INFO"},
+		{slog.LevelWarn, "WARN"},
+		{slog.LevelError, "ERROR"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.level.String(), func(t *testing.T) {
+			result := clog.DefaultLevelFormatter(tc.level)
+			gt.V(t, result).Equal(tc.expected)
+		})
+	}
+}
+
+func TestWithLevelFormatterDefault(t *testing.T) {
+	// Test that without WithLevelFormatter, default behavior is preserved
+	buf := &bytes.Buffer{}
+	handler := clog.New(
+		clog.WithWriter(buf),
+		clog.WithColor(false),
+	)
+	logger := slog.New(handler)
+
+	logger.Info("test message")
+	output := buf.String()
+	gt.S(t, output).Contains("INFO")
+	gt.S(t, output).Contains("test message")
+}

--- a/examples/level_formatter/main.go
+++ b/examples/level_formatter/main.go
@@ -8,108 +8,47 @@ import (
 )
 
 func main() {
-	fmt.Println("=== Default Level Formatter ===")
-	demoDefault()
-
-	fmt.Println("\n=== Custom Fixed Width Formatter (5 chars) ===")
-	demoFixedWidth()
-
-	fmt.Println("\n=== Custom Bracketed Formatter ===")
-	demoBracketed()
-
-	fmt.Println("\n=== Custom Uppercase Formatter ===")
-	demoUppercase()
-}
-
-func demoDefault() {
-	handler := clog.New(
-		clog.WithColor(false),
-		clog.WithSource(true),
-	)
-	logger := slog.New(handler)
-
-	logger.Debug("Debug message", slog.String("key", "value"))
-	logger.Info("Info message", slog.String("key", "value"))
-	logger.Warn("Warning message", slog.String("key", "value"))
-	logger.Error("Error message", slog.String("key", "value"))
-}
-
-func demoFixedWidth() {
 	// Create a formatter that ensures all levels are exactly 5 characters
+	// This works perfectly with color because the formatter is applied
+	// before color codes are added
 	fixedWidthFormatter := func(level slog.Level) string {
 		switch level {
 		case slog.LevelDebug:
-			return "DEBUG"
+			return "DEBUG" // 5 chars
 		case slog.LevelInfo:
-			return "INFO "
+			return "INFO " // 5 chars with trailing space
 		case slog.LevelWarn:
-			return "WARN "
+			return "WARN " // 5 chars with trailing space
 		case slog.LevelError:
-			return "ERROR"
+			return "ERROR" // 5 chars
 		default:
 			return fmt.Sprintf("%-5s", level.String())
 		}
 	}
 
+	// Create handler with color enabled and fixed-width formatter
 	handler := clog.New(
 		clog.WithLevelFormatter(fixedWidthFormatter),
-		clog.WithColor(false),
+		clog.WithColor(true), // Color enabled
 		clog.WithSource(true),
+		clog.WithLevel(slog.LevelDebug), // Enable debug level
 	)
 	logger := slog.New(handler)
 
-	logger.Debug("Debug message", slog.String("key", "value"))
-	logger.Info("Info message", slog.String("key", "value"))
-	logger.Warn("Warning message", slog.String("key", "value"))
-	logger.Error("Error message", slog.String("key", "value"))
-}
+	fmt.Println("=== Fixed-width level formatting with color ===")
+	fmt.Println("All levels are aligned at exactly 5 characters:")
+	fmt.Println()
 
-func demoBracketed() {
-	// Create a formatter that wraps levels in brackets
-	bracketedFormatter := func(level slog.Level) string {
-		return "[" + level.String() + "]"
-	}
+	// Demonstrate all log levels with fixed-width formatting
+	logger.Debug("Debug message - lowest priority", slog.String("status", "verbose"))
+	logger.Info("Info message - normal operations", slog.String("status", "ok"))
+	logger.Warn("Warning message - be careful", slog.String("status", "warning"))
+	logger.Error("Error message - something failed", slog.String("status", "error"))
 
-	handler := clog.New(
-		clog.WithLevelFormatter(bracketedFormatter),
-		clog.WithColor(false),
-		clog.WithSource(true),
-	)
-	logger := slog.New(handler)
-
-	logger.Info("Info message", slog.String("key", "value"))
-	logger.Warn("Warning message", slog.String("key", "value"))
-	logger.Error("Error message", slog.String("key", "value"))
-}
-
-func demoUppercase() {
-	// Create a formatter that adds a prefix and uses uppercase
-	uppercaseFormatter := func(level slog.Level) string {
-		switch level {
-		case slog.LevelDebug:
-			return "DBG"
-		case slog.LevelInfo:
-			return "INF"
-		case slog.LevelWarn:
-			return "WRN"
-		case slog.LevelError:
-			return "ERR"
-		default:
-			return "UNK"
-		}
-	}
-
-	handler := clog.New(
-		clog.WithLevelFormatter(uppercaseFormatter),
-		clog.WithColor(true), // Works with color too
-		clog.WithSource(true),
-	)
-	logger := slog.New(handler)
-
-	logger.Info("Info message", slog.String("key", "value"))
-	logger.Warn("Warning message", slog.String("key", "value"))
-	logger.Error("Error message", slog.String("key", "value"))
-
-	// Show it works with groups too
-	logger.WithGroup("app").Info("Grouped message", slog.Int("count", 42))
+	fmt.Println()
+	fmt.Println("Works with grouped attributes too:")
+	logger.WithGroup("app").Info("Application started", slog.Int("port", 8080))
+	logger.WithGroup("db").Error("Database connection failed", slog.String("err", "timeout"))
+	logger.WithGroup("api").Debug("API request received", slog.String("method", "GET"))
+	logger.WithGroup("auth").Warn("Invalid token attempt", slog.String("ip", "192.168.1.1"))
 }

--- a/examples/level_formatter/main.go
+++ b/examples/level_formatter/main.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/m-mizutani/clog"
+)
+
+func main() {
+	fmt.Println("=== Default Level Formatter ===")
+	demoDefault()
+
+	fmt.Println("\n=== Custom Fixed Width Formatter (5 chars) ===")
+	demoFixedWidth()
+
+	fmt.Println("\n=== Custom Bracketed Formatter ===")
+	demoBracketed()
+
+	fmt.Println("\n=== Custom Uppercase Formatter ===")
+	demoUppercase()
+}
+
+func demoDefault() {
+	handler := clog.New(
+		clog.WithColor(false),
+		clog.WithSource(true),
+	)
+	logger := slog.New(handler)
+
+	logger.Debug("Debug message", slog.String("key", "value"))
+	logger.Info("Info message", slog.String("key", "value"))
+	logger.Warn("Warning message", slog.String("key", "value"))
+	logger.Error("Error message", slog.String("key", "value"))
+}
+
+func demoFixedWidth() {
+	// Create a formatter that ensures all levels are exactly 5 characters
+	fixedWidthFormatter := func(level slog.Level) string {
+		switch level {
+		case slog.LevelDebug:
+			return "DEBUG"
+		case slog.LevelInfo:
+			return "INFO "
+		case slog.LevelWarn:
+			return "WARN "
+		case slog.LevelError:
+			return "ERROR"
+		default:
+			return fmt.Sprintf("%-5s", level.String())
+		}
+	}
+
+	handler := clog.New(
+		clog.WithLevelFormatter(fixedWidthFormatter),
+		clog.WithColor(false),
+		clog.WithSource(true),
+	)
+	logger := slog.New(handler)
+
+	logger.Debug("Debug message", slog.String("key", "value"))
+	logger.Info("Info message", slog.String("key", "value"))
+	logger.Warn("Warning message", slog.String("key", "value"))
+	logger.Error("Error message", slog.String("key", "value"))
+}
+
+func demoBracketed() {
+	// Create a formatter that wraps levels in brackets
+	bracketedFormatter := func(level slog.Level) string {
+		return "[" + level.String() + "]"
+	}
+
+	handler := clog.New(
+		clog.WithLevelFormatter(bracketedFormatter),
+		clog.WithColor(false),
+		clog.WithSource(true),
+	)
+	logger := slog.New(handler)
+
+	logger.Info("Info message", slog.String("key", "value"))
+	logger.Warn("Warning message", slog.String("key", "value"))
+	logger.Error("Error message", slog.String("key", "value"))
+}
+
+func demoUppercase() {
+	// Create a formatter that adds a prefix and uses uppercase
+	uppercaseFormatter := func(level slog.Level) string {
+		switch level {
+		case slog.LevelDebug:
+			return "DBG"
+		case slog.LevelInfo:
+			return "INF"
+		case slog.LevelWarn:
+			return "WRN"
+		case slog.LevelError:
+			return "ERR"
+		default:
+			return "UNK"
+		}
+	}
+
+	handler := clog.New(
+		clog.WithLevelFormatter(uppercaseFormatter),
+		clog.WithColor(true), // Works with color too
+		clog.WithSource(true),
+	)
+	logger := slog.New(handler)
+
+	logger.Info("Info message", slog.String("key", "value"))
+	logger.Warn("Warning message", slog.String("key", "value"))
+	logger.Error("Error message", slog.String("key", "value"))
+
+	// Show it works with groups too
+	logger.WithGroup("app").Info("Grouped message", slog.Int("count", 42))
+}

--- a/handler.go
+++ b/handler.go
@@ -83,7 +83,7 @@ func (x *Handler) Handle(ctx context.Context, record slog.Record) error {
 		logLevel:  record.Level,
 		Timestamp: record.Time.Format(x.cfg.timeFmt),
 		Elapsed:   elapsedDuration(),
-		Level:     record.Level.String(),
+		Level:     x.cfg.levelFormatter(record.Level),
 		Message:   record.Message,
 	}
 	if record.Time.IsZero() {


### PR DESCRIPTION
Like this by [example](https://github.com/m-mizutani/clog/blob/066b6aa09b44dcda0e4fb13aba8e7a7f6cd5ba78/examples/level_formatter/main.go)

<img width="532" height="199" alt="image" src="https://github.com/user-attachments/assets/da0a7599-e914-4479-b674-9f0a8b4d4574" />

